### PR TITLE
fix: inline background-image

### DIFF
--- a/src/assets/scss/_typography.scss
+++ b/src/assets/scss/_typography.scss
@@ -4,6 +4,8 @@ body {
   font-family: $font-family-serif;
   font-size: $font-size-normal;
   letter-spacing: 0.15px;
+
+  --gradient-background-dark: url('~assets/img/bg10.png?inline');
 }
 
 h1,

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -5,7 +5,7 @@ $color-accent-one: #ffdf96;
 $color-accent-two: #ffa99f;
 $color-accent-three: #ff719a;
 
-$gradient-background-dark: url('~assets/img/bg10.png?inline');
+$gradient-background-dark: var(--gradient-background-dark);
 $gradient-accent: linear-gradient(
   90deg,
   $color-accent-one 0%,


### PR DESCRIPTION
Inline l'image de background dans le CSS pour éviter le flash de texte blanc sur fond-blanc au chargement de la page.
L'image est inliné une seule fois grâces à une variable CSS, la variable SCSS `$gradient-background-dark` pointe vers cette variable CSS.