### PR TITLE
fix: add components.dirs property to nuxt config to correctly import icon components

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -174,7 +174,9 @@ export default {
   styleResources: {
     scss: ['@/assets/scss/_variables.scss', '@/assets/scss/_mixins.scss']
   },
-  components: true,
+  components: {
+    dirs: ['@/components', '@/components/icons']
+  },
   buildModules: ['@nuxtjs/style-resources', '@aceforth/nuxt-optimized-images'],
   modules: ['@nuxt/content', '@nuxtjs/sitemap', '@nuxtjs/feed'],
   content: {


### PR DESCRIPTION
Apparemment, les autres composants étaient correctement importé car ils étaient tous préfixé avec le nom du dossier dans lequel ils se trouvaient (ex: `blog/BlogArticle.vue`).

<img width="199" alt="Arbre des fichiers du dossier components" src="https://user-images.githubusercontent.com/7683740/154513239-82453ec1-50ce-44ff-ac3e-491541b5abbf.png">


Par contre, c'est pas mentionné sur la doc https://nuxtjs.org/docs/directory-structure/components/ 🤷‍♂️